### PR TITLE
Allows cli command --remoteHost=http://x.x.x.x:5555

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -34,7 +34,8 @@ var defaultConfig = {
         "version"   : "",
         "logFile"   : null,
         "logLevel"  : "INFO",
-        "logColor"  : false
+        "logColor"  : false,
+        "remoteHost": null
     },
     config = {
         "ip"        : defaultConfig.ip,
@@ -44,7 +45,8 @@ var defaultConfig = {
         "version"   : defaultConfig.version,
         "logFile"   : defaultConfig.logFile,
         "logLevel"  : defaultConfig.logLevel,
-        "logColor"  : defaultConfig.logColor
+        "logColor"  : defaultConfig.logColor,
+        "remoteHost": defaultConfig.remoteHost
     },
     logOutputFile = null,
     logger = require("./logger.js"),

--- a/src/hub_register.js
+++ b/src/hub_register.js
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 /* generate node configuration for this node */
-var nodeconf = function(ip, port, hub, proxy, version) {
+var nodeconf = function(ip, port, hub, proxy, version, remoteHost) {
         var ref$, hubHost, hubPort;
 
         ref$ = hub.match(/([\w\d\.]+):(\d+)/);
@@ -43,6 +43,10 @@ var nodeconf = function(ip, port, hub, proxy, version) {
             platform = "LINUX";
         }
 
+      	var returnHost = "http://" + ip + ":" + port;
+      	if (remoteHost) {
+      	    returnHost = remoteHost;
+      	}
 
         return {
             capabilities: [{
@@ -66,14 +70,14 @@ var nodeconf = function(ip, port, hub, proxy, version) {
                 registerCycle: 5000,
                 role: "wd",
                 url: "http://" + ip + ":" + port,
-                remoteHost: "http://" + ip + ":" + port
+                remoteHost: returnHost
             }
         };
     },
     _log = require("./logger.js").create("HUB Register");
 
 module.exports = {
-    register: function(ip, port, hub, proxy, version) {
+    register: function(ip, port, hub, proxy, version, remoteHost) {
         var page;
 
         try {
@@ -86,7 +90,7 @@ module.exports = {
             /* Register with selenium grid server */
             page.open(hub + 'grid/register', {
                 operation: 'post',
-                data: JSON.stringify(nodeconf(ip, port, hub, proxy, version)),
+                data: JSON.stringify(nodeconf(ip, port, hub, proxy, version, remoteHost)),
                 headers: {
                     'Content-Type': 'application/json'
                 }

--- a/src/main.js
+++ b/src/main.js
@@ -74,12 +74,14 @@ try {
             _log.info("Main", "registering to Selenium HUB"+
                 " '" + ghostdriver.config.hub + "' version: " + ghostdriver.config.version +
                 " using '" + ghostdriver.config.ip + ":" + ghostdriver.config.port + "' with " +
+                (ghostdriver.config.remoteHost ? "remoteHost:" + ghostdriver.config.remoteHost + " " : "") +
                 ghostdriver.config.proxy + " as remote proxy.");
             ghostdriver.hub.register(ghostdriver.config.ip,
                 ghostdriver.config.port,
                 ghostdriver.config.hub,
                 ghostdriver.config.proxy,
-                ghostdriver.config.version);
+                ghostdriver.config.version,
+                ghostdriver.config.remoteHost);
         }
     } else {
         throw new Error("Could not start Ghost Driver");


### PR DESCRIPTION
This is necessary to allow a docker container to bind to the local ip while also providing a the external ip and port of the host for selenium grid to connect back to it.

Currently the remoteHost is automatically set by the binding ip and port but this isnt always what you want. Currently this is over-rideable in the main line selenium docker chrome nodes with: 
-e SE_OPTS="-host $HOSTNAME -port $PORT"

This functionality can be used like:
CMD phantomjs /home/phantomjs/ghostdriver/src/main.js \
—hub=$HUB --ip=`ip -4 addr show eth0| grep -Po 'inet \K[\d.]+'` \
--port=$PORT --remoteHost=$REMOTEHOST

docker run -d -e HUB=http://grid:4444 -e PORT=5555 \
-e REMOTEHOST=http://x.x.x.x:5555 -p 5555:5555